### PR TITLE
Update CI Workflows

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,16 +9,15 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
Diese PR aktualisiert die Actions auf welche, die mit Node 24 kompatibel sind, da Node 20 deprecated ist.

Außerdem wird auf die self-hosted Runner umgestellt